### PR TITLE
Some edits & comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welcome to Healthsea ✨
 Create better access to health with machine learning and natural language processing. 
-A spaCy end-to-end pipeline for analyzing user-generated reviews to supplementary products for their effects on health.
+A spaCy end-to-end pipeline for analyzing user reviews of supplementary products and their effects on health.
 
 ## Creating better access to health 💉
-The goal is to analyze user-generated reviews of supplements and extract their effects on health. We want to create product recommendations for specific health conditions based on what customers wrote in their reviews.
+The goal is to analyze user reviews of supplements and extract their effects on health. We want to create product recommendations for specific health conditions based on what customers wrote in their reviews.
 The usage of complementary medicine is an excellent alternative to conventional medicine when it comes to maintaining health. Due to its rising popularity, consumers have access to a wide variety of products. However, it's likely that most of them are redundant and produced in a "quantity over quality" fashion to maximize profit. This white noise of products makes it hard for customers to find valuable supplements. Additionally, supplement manufacturers are not allowed to claim health benefits for their products if not scientifically approved, increasing manual work for customers.

--- a/project/README.md
+++ b/project/README.md
@@ -2,7 +2,7 @@
 
 # 🪐 spaCy Project: Healthsea
 
-This project trains a Named-Entity-Recognition model, a Text Classification model, and assembles them together with custom components into a finished end-to-end pipeline.
+This project trains a Named Entity Recognition (NER) model, a Text Classification model, and assembles them together with custom components into a finished end-to-end pipeline.
 
 ## 📋 project.yml
 
@@ -21,8 +21,8 @@ Commands are only re-run if their inputs have changed.
 | `requirements` | Install dependencies and requirements |
 | `parse_ner` | Load the annotations to Prodigy and use data-to-spacy to split the data into a training and development set |
 | `parse_textcat` | Parse the textcat annotation file manually into a training and development set |
-| `train_ner` | Train a Named-Entity-Recognition model |
-| `evaluate_ner` | Evaluate a trained Named-Entity-Recognition model |
+| `train_ner` | Train an NER model |
+| `evaluate_ner` | Evaluate a trained NER model |
 | `train_textcat` | Train a Text Classification model |
 | `evaluate_textcat` | Evaluate a trained Text Classification model |
 | `assemble_healthsea` | Assemble trained components into the healthsea pipeline |
@@ -51,9 +51,9 @@ in the project directory.
 
 | File | Source | Description |
 | --- | --- | --- |
-| [`assets/ner/ner_annotation.jsonl`](assets/ner/ner_annotation.jsonl) | Local | Named-Entity-Recognition annotations exported from Prodigy with 5000 examples and 2 labels |
-| [`assets/ner/train.spacy`](assets/ner/train.spacy) | Local | Training dataset for Named-Entity-Recognition |
-| [`assets/ner/dev.spacy`](assets/ner/dev.spacy) | Local | Development dataset for Named-Entity-Recognition |
+| [`assets/ner/ner_annotation.jsonl`](assets/ner/ner_annotation.jsonl) | Local | NER annotations exported from Prodigy with 5000 examples and 2 labels |
+| [`assets/ner/train.spacy`](assets/ner/train.spacy) | Local | Training dataset for NER |
+| [`assets/ner/dev.spacy`](assets/ner/dev.spacy) | Local | Development dataset for NER |
 | [`assets/textcat/textcat_annotation.jsonl`](assets/textcat/textcat_annotation.jsonl) | Local | Text Classification annotations exported from Prodigy with 5000 examples and 4 classes |
 | [`assets/textcat/train.spacy`](assets/textcat/train.spacy) | Local | Training dataset for Text Classification |
 | [`assets/textcat/dev.spacy`](assets/textcat/dev.spacy) | Local | Development dataset for Text Classification |

--- a/project/project.yml
+++ b/project/project.yml
@@ -1,5 +1,5 @@
 title: "Healthsea"
-description: "This project trains a Named-Entity-Recognition model, a Text Classification model, and assembles them together with custom components into a finished end-to-end pipeline."
+description: "This project trains a Named Entity Recognition (NER) model, a Text Classification model, and assembles them together with custom components into a finished end-to-end pipeline."
 # Variables can be referenced across the project.yml using ${vars.var_name}
 vars:
   version: "0.0.0"
@@ -16,7 +16,7 @@ vars:
     model_healthsea: "training/healthsea/${vars.config}"
 
   prodigy:
-    annotation_ner: "healthsea_ner_annotation"
+    ner_db: "healthsea_ner_annotation"
 
   gpu_id: -1
   eval_split: 0.25
@@ -27,14 +27,14 @@ directories: ["assets","training","configs","scripts"]
 
 # Assets that should be downloaded or available in the directory. We're shipping
 # them with the project, so they won't have to be downloaded. But the
-# 'project assets' command still lets you verify that the checksums match.
+# 'project assets' command still lets you verify that all required files are available.
 assets:
   - dest: "assets/ner/ner_annotation.jsonl"
-    description: "Named-Entity-Recognition annotations exported from Prodigy with 5000 examples and 2 labels"
+    description: "NER annotations exported from Prodigy with 5000 examples and 2 labels"
   - dest: "assets/ner/train.spacy"
-    description: "Training dataset for Named-Entity-Recognition"
+    description: "Training dataset for NER"
   - dest: "assets/ner/dev.spacy"
-    description: "Development dataset for Named-Entity-Recognition"
+    description: "Development dataset for NER"
   - dest: "assets/textcat/textcat_annotation.jsonl"
     description: "Text Classification annotations exported from Prodigy with 5000 examples and 4 classes"
   - dest: "assets/textcat/train.spacy"
@@ -76,12 +76,12 @@ commands:
       - "pip install -r requirements.txt"
       - "python -m spacy download en_core_web_lg"
 
-  # Works only with prodigy, training files for the ner are already available in the assets folder
+  # Works only with prodigy. Can be skipped otherwise, as the training files for the NER are already available in the assets folder
   - name: "parse_ner"
     help: "Load the annotations to Prodigy and use data-to-spacy to split the data into a training and development set"
     script:
-      - "python -m prodigy db-in ${vars.prodigy.annotation_ner} assets/ner/ner_annotation.jsonl"
-      - "python -m prodigy data-to-spacy assets/ner/ -n ${vars.prodigy.annotation_ner} -es ${vars.eval_split}"
+      - "python -m prodigy db-in ${vars.prodigy.ner_db} assets/ner/ner_annotation.jsonl"
+      - "python -m prodigy data-to-spacy assets/ner/ -n ${vars.prodigy.ner_db} -es ${vars.eval_split}"
       - "python scripts/parsing/analyze_ner_annotation.py assets/ner/ner_annotation.jsonl"
     deps:
       - "assets/ner/ner_annotation.jsonl"
@@ -89,9 +89,9 @@ commands:
       - "data/ner/${vars.train}.spacy"
       - "data/ner/${vars.dev}.spacy"
 
-  # You can skip this command, the training files are already present in the assets folder
+  # You can skip this command if you're happy with the training files in the assets folder generated with the default split
   - name: "parse_textcat"
-    help: "Parse the textcat annotation file manually into a training and development set"
+    help: "Parse the textcat annotation file into a training and development set"
     script:
       - "python scripts/parsing/parse_textcat_annotation.py assets/textcat/textcat_annotation.jsonl assets/textcat/${vars.train}.spacy assets/textcat/${vars.dev}.spacy ${vars.eval_split}"
     deps:
@@ -101,7 +101,7 @@ commands:
       - "assets/textcat/${vars.dev}.spacy"
 
   - name: "train_ner"
-    help: "Train a Named-Entity-Recognition model"
+    help: "Train an NER model"
     script:
       - "python -m spacy train configs/ner/${vars.config}.cfg --output training/ner/${vars.config}/ --paths.train assets/ner/${vars.train}.spacy --paths.dev assets/ner/${vars.dev}.spacy --paths.init_tok2vec assets/pretrained_weights.bin --gpu-id ${vars.gpu_id}"
     deps:
@@ -112,7 +112,7 @@ commands:
       - ${vars.models.model_ner}
 
   - name: "evaluate_ner"
-    help: "Evaluate a trained Named-Entity-Recognition model"
+    help: "Evaluate a trained NER model"
     script:
       - "python -m spacy evaluate ${vars.models.model_ner} assets/ner/${vars.dev}.spacy --gpu-id ${vars.gpu_id}"
     deps:

--- a/project/scripts/parsing/parse_textcat_annotation.py
+++ b/project/scripts/parsing/parse_textcat_annotation.py
@@ -17,7 +17,7 @@ def main(
     dev_file: Path,
     eval_split: float,
 ):
-    """Parse the textcat annotation into a training and development set."""
+    """Parse the textcat annotations into a training and development set."""
 
     examples = []
     label_dict = {}


### PR DESCRIPTION
Committing some small edits, mainly to align the terminology with how we typically describe these things. But don't feel obliged to merge any of them if you don't agree.

With respect to the README:  perhaps it needs a bit more explanation on how to install things, including optional stuff like Prodigy (>=1.11 for spaCy v3!) & GPU (cuda install, `gpu_id` etc), as well as a short explanation that the subfolder is a `spacy project`, maybe refer to https://spacy.io/usage/projects? Maybe also a quick explanation on how to switch between TRF setup and non-TRF models, and that pretraining only makes sense in the latter case?

### Running `parse_ner` without prodigy installed
Without Prodigy I get a silent error, it just goes back to the terminal.

```
(venv_sea)
$ spacy project run parse_ner
C:\Users\Sofie\git\healthsea\venv_sea\Scripts\python.exe: No module named prodigy

================================= parse_ner =================================
Running command: 'C:\Users\Sofie\git\healthsea\venv_sea\Scripts\python.exe' -m prodigy db-in healthsea_ner_annotation assets/ner/ner_annotation.jsonl
(venv_sea)
```

I'm not sure why this happens and it might be a shortcoming of `spacy projects` that swallows up the error? Either way, users will run into this and not understand what's going on. So maybe we could add a small script that checks whether prodigy is installed, and if not, gives an informative error msg and explains what Prodigy is (and that it's not just pip-installable without license)

